### PR TITLE
Minor change to clean function and added new format function

### DIFF
--- a/R/cprr.R
+++ b/R/cprr.R
@@ -148,15 +148,31 @@ clean <- function(cpr) {
     stop('CPR numbers must be provided as character strings.')
   }
 
-  cpr <- gsub('[^[:alnum:]]+', '', cpr)
+  # :digit: instead of :alnum: removes any hyphens, trailing white spaces, etc.
+  cpr <- gsub('[^[:digit:]]+', '', cpr)
 
   if(any(nchar(cpr[!is.na(cpr)]) != 10)) {
     warning('One or more CPR numbers of incorrect length replaced with NA.')
     cpr[nchar(cpr) != 10] <- NA
   }
 
+  # Check valid date in first 4 digits
+  if(any(is.na(as.Date(substr(cpr,1,6), format="%d%m%y")))) {
+    warning('One or more CPR numbers with invalid DOB replaced with NA.')
+    cpr[is.na(as.Date(substr(cpr,1,6), format="%d%m%y"))] <- NA
+  }
+
   cpr
 }
+
+format <- function(cpr, add_hyphen=FALSE) {
+  cpr <- clean(cpr)
+  if (add_hyphen) {
+    cpr <- paste0(substr(cpr,1,6),"-",substr(cpr,7,10))
+  }
+  cpr
+}
+
 
 #' Modulo 11 check
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -43,6 +43,9 @@ scramble(cpr)
 # Perform modulo 11 check of cpr numbers.
 mod11(cpr)
 
+# Format cpr numbers correctly
+format(cpr, add_hyphen=TRUE)
+
 # Make data frame from build in data set of official test cpr numbers.
 cpr <- test_cpr$cpr
 data.frame(

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-[![Build Status](https://travis-ci.org/anhoej/cprr.svg?branch=master)](https://travis-ci.org/anhoej/cprr) [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/cprr)](https://cran.r-project.org/package=cprr)
 
-cprr
-====
+[![Build
+Status](https://travis-ci.org/anhoej/cprr.svg?branch=master)](https://travis-ci.org/anhoej/cprr)
+[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/cprr)](https://cran.r-project.org/package=cprr)
 
-Calculate date of birth, age, and gender, and generate anonymous sequence numbers from CPR numbers. Also modulo 11 check is available, though this function is only relevant for cpr numbers until 2007.
+# cprr
 
-Examples
---------
+Calculate date of birth, age, and gender, and generate anonymous
+sequence numbers from CPR numbers. Also modulo 11 check is available,
+though this function is only relevant for cpr numbers until 2007.
+
+## Examples
 
 ``` r
 # Load cprr.
@@ -23,7 +26,7 @@ dob(cpr)
 
 # Calculate ages from cpr numbers.
 age(cpr)
-#> [1]  54.06434  55.01437  40.90075  54.06434 154.87748
+#> [1]  60.77207  61.72211  47.60849  60.77207 161.58522
 
 # Calculate genders from cpr numbers.
 gender(cpr)
@@ -31,11 +34,15 @@ gender(cpr)
 
 # Generate anonymous sequence numbers from cpr numbers.
 scramble(cpr)
-#> [1] 4 2 1 4 3
+#> [1] 3 4 2 3 1
 
 # Perform modulo 11 check of cpr numbers.
 mod11(cpr)
 #> [1] FALSE FALSE FALSE FALSE  TRUE
+
+# Format cpr numbers correctly
+format(cpr, add_hyphen=TRUE)
+#> [1] "150863-1111" "020962-4444" "131076-2222" "150863-1111" "211062-5629"
 
 # Make data frame from build in data set of official test cpr numbers.
 cpr <- test_cpr$cpr
@@ -47,40 +54,39 @@ data.frame(
   mod11  = mod11(cpr)
 )
 #>           cpr id        dob gender mod11
-#> 1  0104909995  7 1990-04-01      1 FALSE
-#> 2  0104909989 23 1990-04-01      1 FALSE
-#> 3  0107729995  8 1972-07-01      1 FALSE
-#> 4  0108589995  3 1958-08-01      1 FALSE
-#> 5  0108629996 20 1962-08-01      0 FALSE
-#> 6  0201609995 14 1960-01-02      1 FALSE
-#> 7  0201609996 11 1960-01-02      0 FALSE
-#> 8  0201919990 18 1991-01-02      0 FALSE
-#> 9  0201919995 16 1991-01-02      1 FALSE
-#> 10 0201919996 27 1991-01-02      0 FALSE
-#> 11 0211223989  9 1922-11-02      1 FALSE
-#> 12 0212159995 30 2015-12-02      1 FALSE
+#> 1  0104909995  3 1990-04-01      1 FALSE
+#> 2  0104909989  4 1990-04-01      1 FALSE
+#> 3  0107729995 26 1972-07-01      1 FALSE
+#> 4  0108589995  1 1958-08-01      1 FALSE
+#> 5  0108629996  8 1962-08-01      0 FALSE
+#> 6  0201609995  6 1960-01-02      1 FALSE
+#> 7  0201609996 10 1960-01-02      0 FALSE
+#> 8  0201919990 17 1991-01-02      0 FALSE
+#> 9  0201919995 20 1991-01-02      1 FALSE
+#> 10 0201919996 15 1991-01-02      0 FALSE
+#> 11 0211223989 23 1922-11-02      1 FALSE
+#> 12 0212159995 28 2015-12-02      1 FALSE
 #> 13 0504909989 13 1990-04-05      1 FALSE
-#> 14 0504909995 25 1990-04-05      1 FALSE
-#> 15 0506889996 10 1988-06-05      0 FALSE
-#> 16 1007059995  1 2005-07-10      1 FALSE
-#> 17 1110109996  4 2010-10-11      0 FALSE
-#> 18 1310169995  6 2016-10-13      1 FALSE
-#> 19 1310169996 17 2016-10-13      0 FALSE
-#> 20 1502779995  5 1977-02-15      1 FALSE
-#> 21 1502799995 24 1979-02-15      1 FALSE
-#> 22 1502829995 29 1982-02-15      1 FALSE
-#> 23 1509819996 26 1981-09-15      0 FALSE
-#> 24 2103009996  2 2000-03-21      0 FALSE
-#> 25 2311143995 15 1914-11-23      1 FALSE
-#> 26 2509479989 19 1947-09-25      1 FALSE
-#> 27 2512489996 21 1948-12-25      0 FALSE
-#> 28 2911829996 28 1982-11-29      0 FALSE
-#> 29 3001749995 22 1974-01-30      1 FALSE
-#> 30 3103979995 12 1997-03-31      1 FALSE
+#> 14 0504909995 14 1990-04-05      1 FALSE
+#> 15 0506889996  5 1988-06-05      0 FALSE
+#> 16 1007059995  7 2005-07-10      1 FALSE
+#> 17 1110109996 16 2010-10-11      0 FALSE
+#> 18 1310169995  9 2016-10-13      1 FALSE
+#> 19 1310169996 22 2016-10-13      0 FALSE
+#> 20 1502779995 27 1977-02-15      1 FALSE
+#> 21 1502799995 21 1979-02-15      1 FALSE
+#> 22 1502829995 19 1982-02-15      1 FALSE
+#> 23 1509819996 25 1981-09-15      0 FALSE
+#> 24 2103009996 11 2000-03-21      0 FALSE
+#> 25 2311143995 18 1914-11-23      1 FALSE
+#> 26 2509479989 12 1947-09-25      1 FALSE
+#> 27 2512489996 29 1948-12-25      0 FALSE
+#> 28 2911829996  2 1982-11-29      0 FALSE
+#> 29 3001749995 24 1974-01-30      1 FALSE
+#> 30 3103979995 30 1997-03-31      1 FALSE
 ```
 
-Installation
-------------
+## Installation
 
 You can install development version from github:
 
@@ -95,19 +101,31 @@ Or stable version from CRAN:
 install.packages("cprr")
 ```
 
-About CPR numbers
------------------
+## About CPR numbers
 
-The Danish Personal Identification number (Danish: *CPR-nummer* or *personnummer*) is a national identification number, which is part of the personal information stored in the Civil Registration System (Danish: *[Det Centrale Personregister](https://www.cpr.dk/)*).
+The Danish Personal Identification number (Danish: *CPR-nummer* or
+*personnummer*) is a national identification number, which is part of
+the personal information stored in the Civil Registration System
+(Danish: *[Det Centrale Personregister](https://www.cpr.dk/)*).
 
-It is a ten-digit number with the format DDMMYY-SSSS, where DDMMYY is the date of birth and SSSS is a sequence number. The first digit of the sequence number encodes the century of birth (so that centenarians are distinguished from infants), and the last digit of the sequence number is odd for males and even for females.
+It is a ten-digit number with the format DDMMYY-SSSS, where DDMMYY is
+the date of birth and SSSS is a sequence number. The first digit of the
+sequence number encodes the century of birth (so that centenarians are
+distinguished from infants), and the last digit of the sequence number
+is odd for males and even for females.
 
 The civil register lists only persons who:
 
--   Are born in Denmark of a mother already registered in the civil register, or
--   have their birth or baptism registered in a ’Dansk Elektronisk Kirkebog (DNK)’ (Danish electronic church-book), or
--   reside legally in Denmark for 3 months or more (non-Nordic citizens must also have a residence permit).
+- Are born in Denmark of a mother already registered in the civil
+  register, or
+- have their birth or baptism registered in a ’Dansk Elektronisk
+  Kirkebog (DNK)’ (Danish electronic church-book), or
+- reside legally in Denmark for 3 months or more (non-Nordic citizens
+  must also have a residence permit).
 
-Danish citizens, including newborn babies, who are entitled to Danish citizenship, but are living abroad, do not receive a personal ID number, unless they move to Denmark.
+Danish citizens, including newborn babies, who are entitled to Danish
+citizenship, but are living abroad, do not receive a personal ID number,
+unless they move to Denmark.
 
-Source: <https://en.wikipedia.org/wiki/Personal_identification_number_(Denmark)>
+Source:
+<https://en.wikipedia.org/wiki/Personal_identification_number_(Denmark)>


### PR DESCRIPTION
Added 'format' function to return a vector of cpr numbers with cleaned-up format -- with/without a hypen.  Essentially does the same as the 'clean' function but returns the full cpr vector formatted with or without a hyphen, as preferred.

Minor change to the 'clean' function to remove hyphens and trailing white spaces, etc.